### PR TITLE
Correctly parse errors on Windows

### DIFF
--- a/flycheck-hledger.el
+++ b/flycheck-hledger.el
@@ -77,37 +77,37 @@ https://hledger.org/hledger.html#check."
 
    ;; hledger 1.26 assertions (:LINE:COL)
    (error
-    bol "hledger: Error: balance assertion: " (file-name (minimal-match (one-or-more (not ":")))) ":" line ":" column "\n"
+    bol "hledger" (optional ".exe") ": Error: balance assertion: " (file-name (optional alpha ":") (+ (not ":"))) ":" line ":" column "\n"
     (message (one-or-more bol (zero-or-more nonl) "\n")))
 
    ;; hledger 1.26 balancedwithautoconversion, balancednoautoconversion (:LINE-LINE)
    (error
-    bol "hledger: Error: " (file-name (minimal-match (one-or-more (not ":")))) ":" line "-" end-line "\n"
+    bol "hledger" (optional ".exe") ": Error: " (file-name (optional alpha ":") (+ (not ":"))) ":" line "-" end-line "\n"
     (message (one-or-more bol (zero-or-more nonl) "\n")))
 
    ;; hledger 1.26+
 
    ;; hledger 1.26+ error with LINE-LINE:
    (error
-    bol "hledger: Error: " (file-name (minimal-match (one-or-more (not ":")))) ":" line "-" end-line ":\n" ; first line
+    bol "hledger" (optional ".exe") ": Error: " (file-name (optional alpha ":") (+ (not ":"))) ":" line "-" end-line ":\n" ; first line
     (one-or-more bol (any space digit) (zero-or-more nonl) "\n")                                           ; excerpt lines
     (message (one-or-more bol (zero-or-more nonl) "\n")))                                                  ; message lines
 
    ;; hledger 1.26+ error with LINE:COL-COL:
    (error
-    bol "hledger: Error: " (file-name (minimal-match (one-or-more (not ":")))) ":" line ":" column "-" end-column ":\n"
+    bol "hledger" (optional ".exe") ": Error: " (file-name (optional alpha ":") (+ (not ":"))) ":" line ":" column "-" end-column ":\n"
     (one-or-more bol (any space digit) (zero-or-more nonl) "\n")
     (message (one-or-more bol (zero-or-more nonl) "\n")))
 
    ;; hledger 1.26+ error with LINE:COL:
    (error
-    bol "hledger: Error: " (file-name (minimal-match (one-or-more (not ":")))) ":" line ":" column ":\n"
+    bol "hledger" (optional ".exe") ": Error: " (file-name (optional alpha ":") (+ (not ":"))) ":" line ":" column ":\n"
     (one-or-more bol (any space digit) (zero-or-more nonl) "\n")
     (message (one-or-more bol (zero-or-more nonl) "\n")))
 
    ;; hledger 1.26+ error with LINE:
    (error
-    bol "hledger: Error: " (file-name (minimal-match (one-or-more (not ":")))) ":" line ":\n"
+    bol "hledger" (optional ".exe") ": Error: " (file-name (optional alpha ":") (+ (not ":"))) ":" line ":\n"
     (one-or-more bol (any space digit) (zero-or-more nonl) "\n")
     (message (one-or-more bol (zero-or-more nonl) "\n")))))
 

--- a/flycheck-hledger.el
+++ b/flycheck-hledger.el
@@ -90,26 +90,26 @@ https://hledger.org/hledger.html#check."
    ;; hledger 1.26+ error with LINE-LINE:
    (error
     bol "hledger" (optional ".exe") ": Error: " (file-name (optional alpha ":") (+ (not ":"))) ":" line "-" end-line ":\n" ; first line
-    (one-or-more bol (any space digit) (zero-or-more nonl) "\n")                                           ; excerpt lines
-    (message (one-or-more bol (zero-or-more nonl) "\n")))                                                  ; message lines
+    (one-or-more (or (seq (one-or-more digit) " ") (>= 2 " ")) "| " (zero-or-more nonl) "\n")                   ; excerpt lines
+    (message "\n" (one-or-more bol (zero-or-more nonl) "\n")))                                                  ; message lines
 
    ;; hledger 1.26+ error with LINE:COL-COL:
    (error
     bol "hledger" (optional ".exe") ": Error: " (file-name (optional alpha ":") (+ (not ":"))) ":" line ":" column "-" end-column ":\n"
-    (one-or-more bol (any space digit) (zero-or-more nonl) "\n")
-    (message (one-or-more bol (zero-or-more nonl) "\n")))
+    (one-or-more (or (seq (one-or-more digit) " ") (>= 2 " ")) "| " (zero-or-more nonl) "\n")                   ; excerpt lines
+    (message "\n" (one-or-more bol (zero-or-more nonl) "\n")))
 
    ;; hledger 1.26+ error with LINE:COL:
    (error
     bol "hledger" (optional ".exe") ": Error: " (file-name (optional alpha ":") (+ (not ":"))) ":" line ":" column ":\n"
-    (one-or-more bol (any space digit) (zero-or-more nonl) "\n")
-    (message (one-or-more bol (zero-or-more nonl) "\n")))
+    (one-or-more (or (seq (one-or-more digit) " ") (>= 2 " ")) "| " (zero-or-more nonl) "\n")                   ; excerpt lines
+    (message "\n" (one-or-more bol (zero-or-more nonl) "\n")))
 
    ;; hledger 1.26+ error with LINE:
    (error
     bol "hledger" (optional ".exe") ": Error: " (file-name (optional alpha ":") (+ (not ":"))) ":" line ":\n"
-    (one-or-more bol (any space digit) (zero-or-more nonl) "\n")
-    (message (one-or-more bol (zero-or-more nonl) "\n")))))
+    (one-or-more (or (seq (one-or-more digit) " ") (>= 2 " ")) "| " (zero-or-more nonl) "\n")                   ; excerpt lines
+    (message "\n" (one-or-more bol (zero-or-more nonl) "\n")))))
 
 (add-to-list 'flycheck-checkers 'hledger)
 

--- a/tests/flycheck-hledger-test.el
+++ b/tests/flycheck-hledger-test.el
@@ -79,11 +79,69 @@ The error message.
 The error message.
 "))
 
+(defconst flycheck-hledger-test-error-standard-line-windows
+  '(
+    :expected-file "C:\\data\\file.ledger"
+    :expected-line "1"
+    :expected-message "\nThe error message.\n"
+    :output "hledger: error: C:\\data\\file.ledger:1:
+  | 2022-01-01
+4 |     (a)               1
+  |      ^
+
+The error message.
+"))
+
+(defconst flycheck-hledger-test-error-standard-line-column-windows
+  '(
+    :expected-file "C:\\data\\file.ledger"
+    :expected-line "1"
+    :expected-column "10"
+    :expected-message "\nThe error message.\n"
+    :output "hledger: error: C:\\data\\file.ledger:1:10:
+  | 2022-01-01
+4 |     a               0 = 1
+  |                       ^^^
+
+The error message.
+"))
+
+(defconst flycheck-hledger-test-error-standard-line-line-windows
+  '(
+    :expected-file "C:\\data\\file.ledger"
+    :expected-line "1"
+    :expected-end-line "2"
+    :expected-message "\nThe error message.\n"
+    :output "hledger: error: C:\\data\\file.ledger:1-2:
+3 | 2022-01-01
+  |     a               1
+
+The error message.
+"))
+
+(defconst flycheck-hledger-test-error-standard-line-col-col-windows
+  '(
+    :expected-file "C:\\data\\file.ledger"
+    :expected-line "1"
+    :expected-column "10"
+    :expected-end-column "20"
+    :expected-message "\nThe error message.\n"
+    :output "hledger: error: C:\\data\\file.ledger:1:10-20:
+3 | 2022-01-01
+  |     a               1
+
+The error message.
+"))
+
 (defconst flycheck-hledger-test-error-symbols
   '(flycheck-hledger-test-error-standard-line
     flycheck-hledger-test-error-standard-line-column
     flycheck-hledger-test-error-standard-line-line
-    flycheck-hledger-test-error-standard-line-col-col))
+    flycheck-hledger-test-error-standard-line-col-col
+    flycheck-hledger-test-error-standard-line-windows
+    flycheck-hledger-test-error-standard-line-column-windows
+    flycheck-hledger-test-error-standard-line-line-windows
+    flycheck-hledger-test-error-standard-line-col-col-windows))
 
 (ert-deftest flycheck-hledger-test-error-patterns ()
   (let* ((error-patterns (flycheck-checker-get 'hledger 'error-patterns)))

--- a/tests/flycheck-hledger-test.el
+++ b/tests/flycheck-hledger-test.el
@@ -79,6 +79,29 @@ The error message.
 The error message.
 "))
 
+(defconst flycheck-hledger-test-error-excerpt-with-shuffled-line-numbers
+  '(
+    :expected-file "./file.ledger"
+    :expected-line "2"
+    :expected-message "\nStrict account checking is enabled, and
+account \"a\" has not been declared.
+Consider adding an account directive. Examples:
+
+account a
+account a    ; type:A  ; (L,E,R,X,C,V)\n"
+    :output "hledger.exe: Error: ./file.ledger:2:
+  | 2022-01-01
+2 |     (a)               1
+  |      ^
+
+Strict account checking is enabled, and
+account \"a\" has not been declared.
+Consider adding an account directive. Examples:
+
+account a
+account a    ; type:A  ; (L,E,R,X,C,V)
+"))
+
 (defconst flycheck-hledger-test-error-standard-line-windows
   '(
     :expected-file "C:\\data\\file.ledger"
@@ -133,15 +156,40 @@ The error message.
 The error message.
 "))
 
+(defconst flycheck-hledger-test-error-excerpt-with-shuffled-line-numbers-windows
+  '(
+    :expected-file "C:\\data\\file.ledger"
+    :expected-line "2"
+    :expected-message "\nStrict account checking is enabled, and
+account \"a\" has not been declared.
+Consider adding an account directive. Examples:
+
+account a
+account a    ; type:A  ; (L,E,R,X,C,V)\n"
+    :output "hledger.exe: Error: C:\\data\\file.ledger:2:
+  | 2022-01-01
+2 |     (a)               1
+  |      ^
+
+Strict account checking is enabled, and
+account \"a\" has not been declared.
+Consider adding an account directive. Examples:
+
+account a
+account a    ; type:A  ; (L,E,R,X,C,V)
+"))
+
 (defconst flycheck-hledger-test-error-symbols
   '(flycheck-hledger-test-error-standard-line
     flycheck-hledger-test-error-standard-line-column
     flycheck-hledger-test-error-standard-line-line
     flycheck-hledger-test-error-standard-line-col-col
+    flycheck-hledger-test-error-excerpt-with-shuffled-line-numbers
     flycheck-hledger-test-error-standard-line-windows
     flycheck-hledger-test-error-standard-line-column-windows
     flycheck-hledger-test-error-standard-line-line-windows
-    flycheck-hledger-test-error-standard-line-col-col-windows))
+    flycheck-hledger-test-error-standard-line-col-col-windows
+    flycheck-hledger-test-error-excerpt-with-shuffled-line-numbers-windows))
 
 (ert-deftest flycheck-hledger-test-error-patterns ()
   (let* ((error-patterns (flycheck-checker-get 'hledger 'error-patterns)))


### PR DESCRIPTION
Errors from hledger weren’t recognized as such using Emacs 30 from Git (2023-05-03) with flycheck-hledger from Git (87ed9d4), hledger 1.30, and flycheck 33snapshot on Windows 10. Instead, I kept getting the errors as ‘Suspicious state’ messages in the minibuffer. Some digging showed the following problems:

1. The patterns expected `hledger:` but the output contained `hledger.exe:`.
2. The patterns forbade colons in filenames but, on Windows, these will typically contain colons.
3. A literal `\n` in a pattern wouldn’t match the line endings (I suppose this is because the output contained `\r\n`).

This PR fixes all of those issues and, as far as I can tell, correctly parses all the messages in [hledger’s error tests](https://github.com/simonmichael/hledger/tree/f4508e73d3dc3709bd403487dee56f8cb24eaa5b/hledger/test/errors). I unfortunately can’t test on a Linux machine at present; I don’t anticipate issues, but it’s always possible the line endings would be matched differently there, in which case perhaps the patterns would need something like `(or line-end "\n")`.