### PR TITLE
Correctly parse errors with context or with fewer newlines

### DIFF
--- a/flycheck-hledger.el
+++ b/flycheck-hledger.el
@@ -105,11 +105,12 @@ https://hledger.org/hledger.html#check."
     (one-or-more (or (seq (one-or-more digit) " ") (>= 2 " ")) "| " (zero-or-more nonl) "\n")                   ; excerpt lines
     (message "\n" (one-or-more bol (zero-or-more nonl) "\n")))
 
-   ;; hledger 1.26+ error with LINE:
+   ;; hledger 1.26+ error with LINE and optional context:
    (error
     bol "hledger" (optional ".exe") ": Error: " (file-name (optional alpha ":") (+ (not ":"))) ":" line ":\n"
-    (one-or-more (or (seq (one-or-more digit) " ") (>= 2 " ")) "| " (zero-or-more nonl) "\n")                   ; excerpt lines
-    (message "\n" (one-or-more bol (zero-or-more nonl) "\n")))))
+    (>= 2 (optional "\n") (one-or-more (or (seq (one-or-more digit) " ") (>= 2 " ")) "|" (zero-or-more nonl) "\n")) ; excerpt lines
+    "\n"
+    (message (one-or-more (zero-or-more nonl) (or "\n" string-end))))))
 
 (add-to-list 'flycheck-checkers 'hledger)
 

--- a/flycheck-hledger.el
+++ b/flycheck-hledger.el
@@ -90,20 +90,20 @@ https://hledger.org/hledger.html#check."
    ;; hledger 1.26+ error with LINE-LINE:
    (error
     bol "hledger" (optional ".exe") ": Error: " (file-name (optional alpha ":") (+ (not ":"))) ":" line "-" end-line ":\n" ; first line
-    (one-or-more (or (seq (one-or-more digit) " ") (>= 2 " ")) "| " (zero-or-more nonl) "\n")                   ; excerpt lines
+    (one-or-more (or (seq (one-or-more digit) " ") (>= 2 " ")) "|" (zero-or-more nonl) "\n")                   ; excerpt lines
     (message "\n" (one-or-more bol (zero-or-more nonl) "\n")))                                                  ; message lines
 
    ;; hledger 1.26+ error with LINE:COL-COL:
    (error
     bol "hledger" (optional ".exe") ": Error: " (file-name (optional alpha ":") (+ (not ":"))) ":" line ":" column "-" end-column ":\n"
-    (one-or-more (or (seq (one-or-more digit) " ") (>= 2 " ")) "| " (zero-or-more nonl) "\n")                   ; excerpt lines
+    (one-or-more (or (seq (one-or-more digit) " ") (>= 2 " ")) "|" (zero-or-more nonl) "\n")                   ; excerpt lines
     (message "\n" (one-or-more bol (zero-or-more nonl) "\n")))
 
    ;; hledger 1.26+ error with LINE:COL:
    (error
     bol "hledger" (optional ".exe") ": Error: " (file-name (optional alpha ":") (+ (not ":"))) ":" line ":" column ":\n"
-    (one-or-more (or (seq (one-or-more digit) " ") (>= 2 " ")) "| " (zero-or-more nonl) "\n")                   ; excerpt lines
-    (message "\n" (one-or-more bol (zero-or-more nonl) "\n")))
+    (one-or-more (or (seq (one-or-more digit) " ") (>= 2 " ")) "|" (zero-or-more nonl) "\n")                   ; excerpt lines
+    (message (? "\n") (one-or-more bol (zero-or-more nonl) "\n")))
 
    ;; hledger 1.26+ error with LINE and optional context:
    (error

--- a/tests/flycheck-hledger-test.el
+++ b/tests/flycheck-hledger-test.el
@@ -123,6 +123,22 @@ Ordered dates checking is enabled, and this transaction's
 date (2023-12-12) is out of order with the previous transaction.
 Consider moving this entry into date order, or adjusting its date."))
 
+(defconst flycheck-hledger-test-compressed-error
+  '(
+    :expected-file "./file.ledger"
+    :expected-line "2"
+    :expected-column "13"
+    :expected-message "unexpected newline
+expecting '+', '-', or number
+"
+    :output "hledger.exe: Error: ./file.ledger:2:13:
+  |
+2 |   card  -USD
+  |             ^
+unexpected newline
+expecting '+', '-', or number
+"))
+
 (defconst flycheck-hledger-test-error-standard-line-windows
   '(
     :expected-file "C:\\data\\file.ledger"
@@ -221,19 +237,37 @@ Ordered dates checking is enabled, and this transaction's
 date (2023-12-12) is out of order with the previous transaction.
 Consider moving this entry into date order, or adjusting its date."))
 
+(defconst flycheck-hledger-test-compressed-error-windows
+  '(
+    :expected-file "C:\\data\\file.ledger"
+    :expected-line "2"
+    :expected-column "13"
+    :expected-message "unexpected newline
+expecting '+', '-', or number
+"
+    :output "hledger.exe: Error: C:\\data\\file.ledger:2:13:
+  |
+2 |   card  -USD
+  |             ^
+unexpected newline
+expecting '+', '-', or number
+"))
+
 (defconst flycheck-hledger-test-error-symbols
   '(flycheck-hledger-test-error-standard-line
     flycheck-hledger-test-error-standard-line-column
     flycheck-hledger-test-error-standard-line-line
     flycheck-hledger-test-error-standard-line-col-col
     flycheck-hledger-test-error-excerpt-with-shuffled-line-numbers
+    flycheck-hledger-test-compressed-error
     flycheck-hledger-test-error-standard-line-with-context
     flycheck-hledger-test-error-standard-line-windows
     flycheck-hledger-test-error-standard-line-column-windows
     flycheck-hledger-test-error-standard-line-line-windows
     flycheck-hledger-test-error-standard-line-col-col-windows
     flycheck-hledger-test-error-excerpt-with-shuffled-line-numbers-windows
-    flycheck-hledger-test-error-standard-line-with-context-windows))
+    flycheck-hledger-test-error-standard-line-with-context-windows
+    flycheck-hledger-test-compressed-error-windows))
 
 (ert-deftest flycheck-hledger-test-error-patterns ()
   (let* ((error-patterns (flycheck-checker-get 'hledger 'error-patterns)))

--- a/tests/flycheck-hledger-test.el
+++ b/tests/flycheck-hledger-test.el
@@ -29,7 +29,7 @@
   '(
     :expected-file "./file.ledger"
     :expected-line "1"
-    :expected-message "\nThe error message.\n"
+    :expected-message "The error message.\n"
     :output "hledger: Error: ./file.ledger:1:
   | 2022-01-01
 4 |     (a)               1
@@ -83,7 +83,7 @@ The error message.
   '(
     :expected-file "./file.ledger"
     :expected-line "2"
-    :expected-message "\nStrict account checking is enabled, and
+    :expected-message "Strict account checking is enabled, and
 account \"a\" has not been declared.
 Consider adding an account directive. Examples:
 
@@ -102,11 +102,32 @@ account a
 account a    ; type:A  ; (L,E,R,X,C,V)
 "))
 
+(defconst flycheck-hledger-test-error-standard-line-with-context
+  '(
+    :expected-file "./file.ledger"
+    :expected-line "5"
+    :expected-message "Ordered dates checking is enabled, and this transaction's
+date (2023-12-12) is out of order with the previous transaction.
+Consider moving this entry into date order, or adjusting its date."
+    :output "hledger: Error: ./file.ledger:5:
+1 | 2023-12-14 Payment 2
+  |     card             USD -50
+  |     expenses          USD 50
+
+5 | 2023-12-12 Payment 1
+  | ^^^^^^^^^^
+  |     card             USD -25
+  |     expenses          USD 25
+
+Ordered dates checking is enabled, and this transaction's
+date (2023-12-12) is out of order with the previous transaction.
+Consider moving this entry into date order, or adjusting its date."))
+
 (defconst flycheck-hledger-test-error-standard-line-windows
   '(
     :expected-file "C:\\data\\file.ledger"
     :expected-line "1"
-    :expected-message "\nThe error message.\n"
+    :expected-message "The error message.\n"
     :output "hledger: error: C:\\data\\file.ledger:1:
   | 2022-01-01
 4 |     (a)               1
@@ -160,7 +181,7 @@ The error message.
   '(
     :expected-file "C:\\data\\file.ledger"
     :expected-line "2"
-    :expected-message "\nStrict account checking is enabled, and
+    :expected-message "Strict account checking is enabled, and
 account \"a\" has not been declared.
 Consider adding an account directive. Examples:
 
@@ -179,17 +200,40 @@ account a
 account a    ; type:A  ; (L,E,R,X,C,V)
 "))
 
+(defconst flycheck-hledger-test-error-standard-line-with-context-windows
+  '(
+    :expected-file "C:\\data\\file.ledger"
+    :expected-line "5"
+    :expected-message "Ordered dates checking is enabled, and this transaction's
+date (2023-12-12) is out of order with the previous transaction.
+Consider moving this entry into date order, or adjusting its date."
+    :output "hledger.exe: Error: C:\\data\\file.ledger:5:
+1 | 2023-12-14 Payment 2
+  |     card             USD -50
+  |     expenses          USD 50
+
+5 | 2023-12-12 Payment 1
+  | ^^^^^^^^^^
+  |     card             USD -25
+  |     expenses          USD 25
+
+Ordered dates checking is enabled, and this transaction's
+date (2023-12-12) is out of order with the previous transaction.
+Consider moving this entry into date order, or adjusting its date."))
+
 (defconst flycheck-hledger-test-error-symbols
   '(flycheck-hledger-test-error-standard-line
     flycheck-hledger-test-error-standard-line-column
     flycheck-hledger-test-error-standard-line-line
     flycheck-hledger-test-error-standard-line-col-col
     flycheck-hledger-test-error-excerpt-with-shuffled-line-numbers
+    flycheck-hledger-test-error-standard-line-with-context
     flycheck-hledger-test-error-standard-line-windows
     flycheck-hledger-test-error-standard-line-column-windows
     flycheck-hledger-test-error-standard-line-line-windows
     flycheck-hledger-test-error-standard-line-col-col-windows
-    flycheck-hledger-test-error-excerpt-with-shuffled-line-numbers-windows))
+    flycheck-hledger-test-error-excerpt-with-shuffled-line-numbers-windows
+    flycheck-hledger-test-error-standard-line-with-context-windows))
 
 (ert-deftest flycheck-hledger-test-error-patterns ()
   (let* ((error-patterns (flycheck-checker-get 'hledger 'error-patterns)))


### PR DESCRIPTION
I’ve added tests for the two errors I discovered were incorrectly parsed. The rectifications required tweaking the whitespace matched by the error patterns, so I updated any failing tests as well. Everything passes for me at present. Do let me know in case anything isn’t working correctly!

Closes #21